### PR TITLE
加入 i18n 配置與 next-intl 支援

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import type { Metadata } from "next"
 import { Space_Grotesk, DM_Sans } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
+import { I18nProvider } from "@/lib/i18n"
+import { getLocale } from "next-intl/server"
 import "./globals.css"
 
 const spaceGrotesk = Space_Grotesk({
@@ -34,19 +36,22 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const locale = await getLocale()
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <link rel="icon" href="/favicon-32x32.png" />
       </head>
       <body className={`font-sans ${spaceGrotesk.variable} ${dmSans.variable} antialiased`}>
-        <Suspense fallback={null}>{children}</Suspense>
-        <Analytics />
+        <I18nProvider locale={locale}>
+          <Suspense fallback={null}>{children}</Suspense>
+          <Analytics />
+        </I18nProvider>
       </body>
     </html>
   )

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { NextIntlClientProvider } from 'next-intl'
+import type { ReactNode } from 'react'
+
+interface I18nProviderProps {
+  locale: string
+  messages?: Record<string, unknown>
+  children: ReactNode
+}
+
+export function I18nProvider({ locale, messages = {}, children }: I18nProviderProps) {
+  return (
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      {children}
+    </NextIntlClientProvider>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  i18n: {
+    locales: ["ms", "en", "zh-CN"],
+    defaultLocale: "en",
+  },
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lucide-react": "^0.454.0",
     "next": "14.2.16",
     "next-themes": "latest",
+    "next-intl": "^3.16.0",
     "react": "^18",
     "react-day-picker": "9.8.0",
     "react-dom": "^18",


### PR DESCRIPTION
## 摘要
- 設定 `next.config.mjs` 的 i18n 參數，支援 ms、en、zh-CN 語系
- 新增 `I18nProvider` 並在根 layout 以當前語系設定 `<html lang>`
- 加入 `next-intl` 依賴以提供語系環境

## 測試
- `pnpm lint` *(失敗：命令不存在)*
- `pnpm build` *(失敗：命令不存在)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6365346083298288cfd4f83bfcd1