### PR TITLE
feat: 新增語言切換器

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Analytics } from "@vercel/analytics/next"
 import { Suspense } from "react"
 import { I18nProvider } from "@/lib/i18n"
 import { getLocale } from "next-intl/server"
+import { LanguageSwitcher } from "@/components/language-switcher"
 import "./globals.css"
 
 const spaceGrotesk = Space_Grotesk({
@@ -49,6 +50,9 @@ export default async function RootLayout({
       </head>
       <body className={`font-sans ${spaceGrotesk.variable} ${dmSans.variable} antialiased`}>
         <I18nProvider locale={locale}>
+          <div className="p-4">
+            <LanguageSwitcher />
+          </div>
           <Suspense fallback={null}>{children}</Suspense>
           <Analytics />
         </I18nProvider>

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next-intl/link'
+import { useLocale, usePathname } from 'next-intl/client'
+import { Button } from '@/components/ui/button'
+
+const languages = [
+  { code: 'ms', label: 'ms' },
+  { code: 'en', label: 'en' },
+  { code: 'zh-CN', label: 'zh-CN' },
+]
+
+export function LanguageSwitcher() {
+  const locale = useLocale()
+  const pathname = usePathname()
+
+  return (
+    <div className="flex gap-2">
+      {languages.map(({ code, label }) => (
+        <Button
+          key={code}
+          variant={locale === code ? 'default' : 'outline'}
+          size="sm"
+          asChild
+        >
+          <Link href={pathname} locale={code}>
+            {label}
+          </Link>
+        </Button>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新增 LanguageSwitcher 元件以切換 ms、en、zh-CN 語系
- 在全域佈局加入語言切換器，所有頁面皆可使用

## Testing
- `pnpm lint` (失敗：需要互動式設定 ESLint)


------
https://chatgpt.com/codex/tasks/task_e_68bd6979129c832982591a99cd2915ac