### PR TITLE
使用翻譯鍵統一站內文字

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,8 +4,10 @@ import { Heart, Phone, MapPin, Clock, MessageCircle } from "lucide-react"
 import Link from "next/link"
 import { MobileNav } from "@/components/mobile-nav"
 import Image from "next/image"
+import { useTranslations } from "next-intl"
 
 export default function ContactPage() {
+  const t = useTranslations("common")
   return (
     <div className="min-h-screen">
       {/* Header */}
@@ -20,13 +22,13 @@ export default function ContactPage() {
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center gap-6">
               <Link href="/" className="text-foreground hover:text-primary transition-colors">
-                首页
+                {t("nav.home")}
               </Link>
               <Link href="/products" className="text-foreground hover:text-primary transition-colors">
-                产品展示
+                {t("nav.products")}
               </Link>
               <Link href="/contact" className="text-primary font-semibold">
-                联系我们
+                {t("nav.contact")}
               </Link>
             </nav>
 
@@ -40,11 +42,11 @@ export default function ContactPage() {
       <section className="bg-gradient-to-br from-card to-background py-12 sm:py-20">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-3xl sm:text-5xl md:text-6xl font-heading font-bold text-foreground mb-4 sm:mb-6 text-balance">
-            联系我们
+            {t("contact.heroTitle")}
             <span className="text-primary block">You & Me Snacks Gift</span>
           </h2>
           <p className="text-lg sm:text-xl text-muted-foreground mb-6 sm:mb-8 max-w-2xl mx-auto text-pretty px-4">
-            欢迎来到我们的实体店面，或通过以下方式与我们联系
+            {t("contact.heroSubtitle")}
           </p>
         </div>
       </section>
@@ -55,17 +57,19 @@ export default function ContactPage() {
           <div className="grid gap-6 sm:gap-8 lg:grid-cols-2 mb-12">
             {/* Contact Details */}
             <div className="space-y-6">
-              <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6">联系信息</h3>
+              <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6">
+                {t("contact.infoTitle")}
+              </h3>
 
               <Card>
                 <CardContent className="p-6">
                   <div className="flex items-start gap-4">
                     <Phone className="h-6 w-6 text-primary flex-shrink-0 mt-1" />
                     <div>
-                      <h4 className="font-semibold text-foreground mb-2">电话联系</h4>
+                      <h4 className="font-semibold text-foreground mb-2">{t("contact.phoneTitle")}</h4>
                       <p className="text-muted-foreground mb-2">018-313 7277</p>
                       <Button size="sm" asChild>
-                        <a href="tel:0183137277">立即拨打</a>
+                        <a href="tel:0183137277">{t("contact.phoneButton")}</a>
                       </Button>
                     </div>
                   </div>
@@ -77,11 +81,11 @@ export default function ContactPage() {
                   <div className="flex items-start gap-4">
                     <MessageCircle className="h-6 w-6 text-primary flex-shrink-0 mt-1" />
                     <div>
-                      <h4 className="font-semibold text-foreground mb-2">WhatsApp</h4>
-                      <p className="text-muted-foreground mb-2">快速咨询和订购</p>
+                      <h4 className="font-semibold text-foreground mb-2">{t("contact.whatsappTitle")}</h4>
+                      <p className="text-muted-foreground mb-2">{t("contact.whatsappDesc")}</p>
                       <Button size="sm" asChild>
                         <a href="https://wa.me/60183137277" target="_blank" rel="noopener noreferrer">
-                          WhatsApp联系
+                          {t("contact.whatsappButton")}
                         </a>
                       </Button>
                     </div>
@@ -94,7 +98,7 @@ export default function ContactPage() {
                   <div className="flex items-start gap-4">
                     <MapPin className="h-6 w-6 text-primary flex-shrink-0 mt-1" />
                     <div>
-                      <h4 className="font-semibold text-foreground mb-2">店面地址</h4>
+                      <h4 className="font-semibold text-foreground mb-2">{t("contact.addressTitle")}</h4>
                       <p className="text-muted-foreground mb-2">
                         Ground Floor, 2A, Jalan Semenyih Sentral 6,
                         <br />
@@ -112,10 +116,10 @@ export default function ContactPage() {
                   <div className="flex items-start gap-4">
                     <Clock className="h-6 w-6 text-primary flex-shrink-0 mt-1" />
                     <div>
-                      <h4 className="font-semibold text-foreground mb-2">营业时间</h4>
+                      <h4 className="font-semibold text-foreground mb-2">{t("contact.hoursTitle")}</h4>
                       <div className="text-muted-foreground space-y-1">
-                        <p>周一至周六: 9:00 AM - 7:00 PM</p>
-                        <p>周日: 10:00 AM - 6:00 PM</p>
+                        <p>{t("contact.hoursWeekday")}</p>
+                        <p>{t("contact.hoursSunday")}</p>
                       </div>
                     </div>
                   </div>
@@ -125,7 +129,9 @@ export default function ContactPage() {
 
             {/* Store Photo */}
             <div className="space-y-6">
-              <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6">店面展示</h3>
+              <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6">
+                {t("contact.storeTitle")}
+              </h3>
 
               <Card className="overflow-hidden">
                 <div className="aspect-[4/3] relative">
@@ -140,7 +146,7 @@ export default function ContactPage() {
                 <CardContent className="p-6">
                   <h4 className="font-semibold text-foreground mb-2">You And Me Snacks Gift Wholesale Enterprise</h4>
                   <p className="text-muted-foreground">
-                    我们的实体店面展示各种精美的气球、花束和礼品。欢迎亲临选购，体验我们的优质产品和服务。
+                    {t("contact.storeDesc")}
                   </p>
                 </CardContent>
               </Card>
@@ -149,7 +155,9 @@ export default function ContactPage() {
 
           {/* Google Map */}
           <div className="mb-12">
-            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6 text-center">店面位置</h3>
+            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-6 text-center">
+              {t("contact.locationTitle")}
+            </h3>
             <Card className="overflow-hidden">
               <div className="aspect-video">
                 <iframe
@@ -168,17 +176,19 @@ export default function ContactPage() {
 
           {/* Call to Action */}
           <div className="text-center">
-            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-4">准备好选购了吗？</h3>
+            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-4">
+              {t("contact.ctaTitle")}
+            </h3>
             <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-              浏览我们的产品展示，或直接联系我们了解更多信息
+              {t("contact.ctaDesc")}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button size="lg" asChild>
-                <Link href="/products">浏览产品</Link>
+                <Link href="/products">{t("home.cta.viewProducts")}</Link>
               </Button>
               <Button variant="outline" size="lg" asChild>
                 <a href="https://wa.me/60183137277" target="_blank" rel="noopener noreferrer">
-                  WhatsApp咨询
+                  {t("contact.ctaWhatsapp")}
                 </a>
               </Button>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,8 +6,11 @@ import Link from "next/link"
 import { MobileNav } from "@/components/mobile-nav"
 import { products, categories } from "@/data/products"
 import Image from "next/image"
+import { useTranslations } from "next-intl"
 
 export default function HomePage() {
+  const t = useTranslations("common")
+
   const getCategoryPreview = (categoryId: string) => {
     const categoryProducts = products.filter((p) => p.category === categoryId)
     return categoryProducts.slice(0, 3) // Get first 3 products as preview
@@ -35,10 +38,10 @@ export default function HomePage() {
             {/* Desktop Navigation */}
             <nav className="hidden md:flex items-center gap-6">
               <Link href="/products" className="text-foreground hover:text-primary transition-colors">
-                产品展示
+                {t("nav.products")}
               </Link>
               <Link href="/contact" className="text-foreground hover:text-primary transition-colors">
-                联系我们
+                {t("nav.contact")}
               </Link>
             </nav>
 
@@ -52,17 +55,17 @@ export default function HomePage() {
       <section className="bg-gradient-to-br from-card to-background py-12 sm:py-20">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-3xl sm:text-5xl md:text-6xl font-heading font-bold text-foreground mb-4 sm:mb-6 text-balance">
-            精美礼品展示
-            <span className="text-primary block">让每个时刻更特别</span>
+            {t("home.heroTitle")}
+            <span className="text-primary block">{t("home.heroSubtitle")}</span>
           </h2>
           <p className="text-lg sm:text-xl text-muted-foreground mb-6 sm:mb-8 max-w-2xl mx-auto text-pretty px-4">
-            气球、花束、巧克力礼盒等多样化产品，为您的庆祝时刻增添温馨与甜蜜
+            {t("home.heroDescription")}
           </p>
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4">
             <Button size="lg" className="text-base sm:text-lg px-6 sm:px-8 h-12 sm:h-auto" asChild>
               <Link href="/products">
                 <Eye className="h-4 w-4 sm:h-5 sm:w-5 mr-2" />
-                浏览产品
+                {t("home.cta.viewProducts")}
               </Link>
             </Button>
             <Button
@@ -71,7 +74,7 @@ export default function HomePage() {
               className="text-base sm:text-lg px-6 sm:px-8 h-12 sm:h-auto bg-transparent"
               asChild
             >
-              <Link href="/contact">联系我们</Link>
+              <Link href="/contact">{t("home.cta.contactUs")}</Link>
             </Button>
           </div>
         </div>
@@ -81,8 +84,12 @@ export default function HomePage() {
       <section id="products" className="py-12 sm:py-16">
         <div className="container mx-auto px-4">
           <div className="text-center mb-8 sm:mb-12">
-            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-3 sm:mb-4">产品展示</h3>
-            <p className="text-muted-foreground text-base sm:text-lg">精选多样化的礼品系列</p>
+            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-3 sm:mb-4">
+              {t("nav.products")}
+            </h3>
+            <p className="text-muted-foreground text-base sm:text-lg">
+              {t("home.featuredSubtitle")}
+            </p>
           </div>
 
           <div className="grid gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mb-8 sm:mb-12">
@@ -112,18 +119,24 @@ export default function HomePage() {
                   </div>
                   <CardContent className="p-4 sm:p-6">
                     <div className="flex items-center gap-2 mb-3">
-                      <Badge variant="secondary">{category.count}个产品</Badge>
+                      <Badge variant="secondary">
+                        {t("home.productCount", { count: category.count })}
+                      </Badge>
                       <div className="flex items-center gap-1">
                         <Star className="h-4 w-4 fill-accent text-accent" />
-                        <span className="text-sm text-muted-foreground">4.8分</span>
+                        <span className="text-sm text-muted-foreground">
+                          {t("home.ratingValue", { rating: 4.8 })}
+                        </span>
                       </div>
                     </div>
                     <h4 className="text-lg sm:text-xl font-heading font-bold text-foreground mb-2">{category.name}</h4>
                     <p className="text-muted-foreground mb-4 text-sm sm:text-base">
-                      {mainProduct ? mainProduct.description : `精选${category.name}系列产品`}
+                      {mainProduct
+                        ? mainProduct.description
+                        : t("home.categoryDescription", { name: category.name })}
                     </p>
                     <Button asChild size="sm" className="w-full">
-                      <Link href={`/products?category=${category.id}`}>查看详情</Link>
+                      <Link href={`/products?category=${category.id}`}>{t("home.viewDetails")}</Link>
                     </Button>
                   </CardContent>
                 </Card>
@@ -137,25 +150,41 @@ export default function HomePage() {
       <section className="py-12 sm:py-16 bg-muted">
         <div className="container mx-auto px-4">
           <div className="text-center mb-8 sm:mb-12">
-            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-3 sm:mb-4">庆祝时刻</h3>
-            <p className="text-muted-foreground text-base sm:text-lg">为每个特殊场合找到完美的礼品</p>
+            <h3 className="text-2xl sm:text-3xl font-heading font-bold text-foreground mb-3 sm:mb-4">
+              {t("home.celebration.title")}
+            </h3>
+            <p className="text-muted-foreground text-base sm:text-lg">
+              {t("home.celebration.subtitle")}
+            </p>
           </div>
 
           <div className="grid gap-6 sm:gap-6 md:grid-cols-3">
             <div className="text-center">
               <div className="text-3xl sm:text-4xl mb-3 sm:mb-4">🎂</div>
-              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">生日庆祝</h4>
-              <p className="text-muted-foreground text-sm sm:text-base">让生日更加特别难忘</p>
+              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">
+                {t("home.celebration.birthday.title")}
+              </h4>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                {t("home.celebration.birthday.desc")}
+              </p>
             </div>
             <div className="text-center">
               <div className="text-3xl sm:text-4xl mb-3 sm:mb-4">💕</div>
-              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">浪漫纪念</h4>
-              <p className="text-muted-foreground text-sm sm:text-base">表达爱意的完美选择</p>
+              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">
+                {t("home.celebration.romantic.title")}
+              </h4>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                {t("home.celebration.romantic.desc")}
+              </p>
             </div>
             <div className="text-center">
               <div className="text-3xl sm:text-4xl mb-3 sm:mb-4">🎉</div>
-              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">节日庆典</h4>
-              <p className="text-muted-foreground text-sm sm:text-base">为节日增添欢乐气氛</p>
+              <h4 className="text-lg sm:text-xl font-heading font-semibold mb-2">
+                {t("home.celebration.festival.title")}
+              </h4>
+              <p className="text-muted-foreground text-sm sm:text-base">
+                {t("home.celebration.festival.desc")}
+              </p>
             </div>
           </div>
         </div>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -10,8 +10,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { MobileNav } from "@/components/mobile-nav"
 import { Phone, MapPin, Facebook, Instagram, ChevronLeft, ChevronRight } from "lucide-react"
 import { products, categories } from "@/data/products"
+import { useTranslations } from "next-intl"
 
 export default function ProductsPage() {
+  const t = useTranslations("common")
   const [selectedCategory, setSelectedCategory] = useState<string>("all")
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
 
@@ -50,13 +52,13 @@ export default function ProductsPage() {
             {/* Desktop Navigation */}
             <nav className="hidden md:flex space-x-8">
               <Link href="/" className="text-gray-700 hover:text-red-600 transition-colors">
-                首页
+                {t("nav.home")}
               </Link>
               <Link href="/products" className="text-red-600 font-medium">
-                产品展示
+                {t("nav.products")}
               </Link>
               <Link href="/contact" className="text-gray-700 hover:text-red-600 transition-colors">
-                联系我们
+                {t("nav.contact")}
               </Link>
             </nav>
 
@@ -70,9 +72,9 @@ export default function ProductsPage() {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Page Header */}
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">产品展示</h1>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">{t("products.heroTitle")}</h1>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            浏览我们精心挑选的礼品系列，从气球装饰到精美花束，为您的特殊时刻增添美好回忆
+            {t("products.heroSubtitle")}
           </p>
         </div>
 
@@ -122,7 +124,7 @@ export default function ProductsPage() {
                     <Dialog>
                       <DialogTrigger asChild>
                         <Button size="sm" className="bg-red-600 hover:bg-red-700 w-full" onClick={resetImageIndex}>
-                          查看详情
+                          {t("products.viewDetails")}
                         </Button>
                       </DialogTrigger>
                       <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
@@ -211,15 +213,15 @@ export default function ProductsPage() {
 
         {filteredProducts.length === 0 && (
           <div className="text-center py-12">
-            <p className="text-gray-500 text-lg">该分类暂无产品，敬请期待！</p>
+            <p className="text-gray-500 text-lg">{t("products.noProducts")}</p>
           </div>
         )}
 
         {/* Contact Section */}
         <section id="contact" className="bg-white rounded-2xl shadow-lg p-8 mb-8">
           <div className="text-center mb-8">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">联系我们</h2>
-            <p className="text-gray-600">对我们的产品感兴趣？欢迎通过以下方式联系我们咨询和订购</p>
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">{t("products.contactTitle")}</h2>
+            <p className="text-gray-600">{t("products.contactSubtitle")}</p>
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -251,7 +253,7 @@ export default function ProductsPage() {
               <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-3">
                 <MapPin className="h-6 w-6 text-red-600" />
               </div>
-              <h3 className="font-semibold text-gray-900 mb-2">地址</h3>
+              <h3 className="font-semibold text-gray-900 mb-2">{t("contact.addressTitle")}</h3>
               <p className="text-gray-600">Semenyih, Selangor</p>
             </div>
           </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -11,10 +11,55 @@
     "cta": {
       "viewProducts": "View Products",
       "contactUs": "Contact Us"
+    },
+    "featuredSubtitle": "A curated variety of gifts",
+    "productCount": "{count} products",
+    "ratingValue": "Rated {rating}",
+    "categoryDescription": "Selected {name} products",
+    "viewDetails": "View Details",
+    "celebration": {
+      "title": "Celebration Moments",
+      "subtitle": "Find the perfect gift for every special occasion",
+      "birthday": {
+        "title": "Birthday Celebration",
+        "desc": "Make birthdays extra special"
+      },
+      "romantic": {
+        "title": "Romantic Moments",
+        "desc": "Perfect for expressing love"
+      },
+      "festival": {
+        "title": "Festive Events",
+        "desc": "Add joy to the holidays"
+      }
     }
   },
   "contact": {
-    "title": "Contact Us",
-    "subtitle": "Visit our store or reach us through the following methods"
+    "heroTitle": "Contact Us",
+    "heroSubtitle": "Visit our store or reach us through the following methods",
+    "infoTitle": "Contact Information",
+    "phoneTitle": "Phone",
+    "phoneButton": "Call Now",
+    "whatsappTitle": "WhatsApp",
+    "whatsappDesc": "Quick inquiries and orders",
+    "whatsappButton": "WhatsApp Us",
+    "addressTitle": "Store Address",
+    "hoursTitle": "Business Hours",
+    "hoursWeekday": "Mon-Sat: 9:00 AM - 7:00 PM",
+    "hoursSunday": "Sun: 10:00 AM - 6:00 PM",
+    "storeTitle": "Store Showcase",
+    "storeDesc": "Our store displays various balloons, bouquets and gifts. Visit us to experience our quality products and service.",
+    "locationTitle": "Store Location",
+    "ctaTitle": "Ready to shop?",
+    "ctaDesc": "Browse our products or contact us for more information",
+    "ctaWhatsapp": "WhatsApp Inquiry"
+  },
+  "products": {
+    "heroTitle": "Products",
+    "heroSubtitle": "Browse our curated selection of gifts, from balloon decorations to beautiful bouquets, to enhance your special moments",
+    "noProducts": "No products in this category yet. Stay tuned!",
+    "contactTitle": "Contact Us",
+    "contactSubtitle": "Interested in our products? Contact us via the following methods for inquiries and orders",
+    "viewDetails": "View Details"
   }
 }

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -11,10 +11,55 @@
     "cta": {
       "viewProducts": "Lihat Produk",
       "contactUs": "Hubungi Kami"
+    },
+    "featuredSubtitle": "Pelbagai hadiah pilihan",
+    "productCount": "{count} produk",
+    "ratingValue": "Penilaian {rating}",
+    "categoryDescription": "Produk pilihan {name}",
+    "viewDetails": "Lihat Butiran",
+    "celebration": {
+      "title": "Detik Perayaan",
+      "subtitle": "Temui hadiah sempurna untuk setiap acara istimewa",
+      "birthday": {
+        "title": "Sambutan Hari Lahir",
+        "desc": "Jadikan hari lahir lebih istimewa"
+      },
+      "romantic": {
+        "title": "Kenangan Romantik",
+        "desc": "Pilihan terbaik untuk meluahkan kasih sayang"
+      },
+      "festival": {
+        "title": "Perayaan",
+        "desc": "Tambah keceriaan pada musim perayaan"
+      }
     }
   },
   "contact": {
-    "title": "Hubungi Kami",
-    "subtitle": "Kunjungi kedai kami atau hubungi kami melalui cara berikut"
+    "heroTitle": "Hubungi Kami",
+    "heroSubtitle": "Kunjungi kedai kami atau hubungi kami melalui cara berikut",
+    "infoTitle": "Maklumat Hubungan",
+    "phoneTitle": "Telefon",
+    "phoneButton": "Hubungi Sekarang",
+    "whatsappTitle": "WhatsApp",
+    "whatsappDesc": "Pertanyaan dan tempahan pantas",
+    "whatsappButton": "Hubungi di WhatsApp",
+    "addressTitle": "Alamat Kedai",
+    "hoursTitle": "Waktu Perniagaan",
+    "hoursWeekday": "Isnin-Sabtu: 9:00 AM - 7:00 PM",
+    "hoursSunday": "Ahad: 10:00 AM - 6:00 PM",
+    "storeTitle": "Pameran Kedai",
+    "storeDesc": "Kedai kami mempamerkan pelbagai belon, sejambak bunga dan hadiah. Datanglah untuk merasai produk dan perkhidmatan kami yang berkualiti.",
+    "locationTitle": "Lokasi Kedai",
+    "ctaTitle": "Sedia untuk membeli?",
+    "ctaDesc": "Lihat produk kami atau hubungi kami untuk maklumat lanjut",
+    "ctaWhatsapp": "Pertanyaan WhatsApp"
+  },
+  "products": {
+    "heroTitle": "Produk",
+    "heroSubtitle": "Lihat pilihan hadiah kami, dari hiasan belon hingga sejambak indah, untuk memeriahkan detik istimewa anda",
+    "noProducts": "Belum ada produk dalam kategori ini. Nantikan!",
+    "contactTitle": "Hubungi Kami",
+    "contactSubtitle": "Berminat dengan produk kami? Hubungi kami melalui cara berikut untuk pertanyaan dan tempahan",
+    "viewDetails": "Lihat Butiran"
   }
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -11,10 +11,55 @@
     "cta": {
       "viewProducts": "浏览产品",
       "contactUs": "联系我们"
+    },
+    "featuredSubtitle": "精选多样化的礼品系列",
+    "productCount": "{count}个产品",
+    "ratingValue": "{rating}分",
+    "categoryDescription": "精选{name}系列产品",
+    "viewDetails": "查看详情",
+    "celebration": {
+      "title": "庆祝时刻",
+      "subtitle": "为每个特殊场合找到完美的礼品",
+      "birthday": {
+        "title": "生日庆祝",
+        "desc": "让生日更加特别难忘"
+      },
+      "romantic": {
+        "title": "浪漫纪念",
+        "desc": "表达爱意的完美选择"
+      },
+      "festival": {
+        "title": "节日庆典",
+        "desc": "为节日增添欢乐气氛"
+      }
     }
   },
   "contact": {
-    "title": "联系我们",
-    "subtitle": "欢迎来到我们的实体店面，或通过以下方式与我们联系"
+    "heroTitle": "联系我们",
+    "heroSubtitle": "欢迎来到我们的实体店面，或通过以下方式与我们联系",
+    "infoTitle": "联系信息",
+    "phoneTitle": "电话联系",
+    "phoneButton": "立即拨打",
+    "whatsappTitle": "WhatsApp",
+    "whatsappDesc": "快速咨询和订购",
+    "whatsappButton": "WhatsApp联系",
+    "addressTitle": "店面地址",
+    "hoursTitle": "营业时间",
+    "hoursWeekday": "周一至周六: 9:00 AM - 7:00 PM",
+    "hoursSunday": "周日: 10:00 AM - 6:00 PM",
+    "storeTitle": "店面展示",
+    "storeDesc": "我们的实体店面展示各种精美的气球、花束和礼品。欢迎亲临选购，体验我们的优质产品和服务。",
+    "locationTitle": "店面位置",
+    "ctaTitle": "准备好选购了吗？",
+    "ctaDesc": "浏览我们的产品展示，或直接联系我们了解更多信息",
+    "ctaWhatsapp": "WhatsApp咨询"
+  },
+  "products": {
+    "heroTitle": "产品展示",
+    "heroSubtitle": "浏览我们精心挑选的礼品系列，从气球装饰到精美花束，为您的特殊时刻增添美好回忆",
+    "noProducts": "该分类暂无产品，敬请期待！",
+    "contactTitle": "联系我们",
+    "contactSubtitle": "对我们的产品感兴趣？欢迎通过以下方式联系我们咨询和订购",
+    "viewDetails": "查看详情"
   }
 }


### PR DESCRIPTION
## 摘要
- 將首頁、產品頁及聯絡頁的文字改為使用 `next-intl` 的 `t` 取得翻譯
- 擴充 `common.json` 翻譯檔，納入常用 UI 文案與頁面標題

## 測試
- `pnpm lint` *(失敗：提示需要額外設定 ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6c4a954083299b4dbc001c302533