### PR TITLE
新增共享導覽設定並修正語言切換器導入路徑

### DIFF
--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next-intl/link'
-import { useLocale, usePathname } from 'next-intl/client'
+import { Link, usePathname } from '@/lib/navigation'
+import { useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 
 const languages = [

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,6 @@
+import { createSharedPathnamesNavigation } from 'next-intl/navigation'
+
+export const { Link, usePathname } = createSharedPathnamesNavigation({
+  locales: ['ms', 'en', 'zh-CN'],
+})
+


### PR DESCRIPTION
## Summary
- 使用 `createSharedPathnamesNavigation` 新增共享導航，提供 `Link` 與 `usePathname`，並設定 `ms/en/zh-CN` 地區
- 調整語言切換器改用新的導覽工具與 `next-intl` 的 `useLocale`

## Testing
- `pnpm run lint`（⚠️ 需互動式 ESLint 設定，無法自動完成）
- `pnpm run build`（⚠️ 因為無法下載 Google Fonts 而失敗）

------
https://chatgpt.com/codex/tasks/task_e_68bd74d04f44832985cfd481dcf86741