### PR TITLE
新增 next-intl 設定檔

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,0 +1,6 @@
+import {NextIntlConfig} from 'next-intl';
+const config: NextIntlConfig = {
+  locales: ['ms', 'en', 'zh-CN'],
+  defaultLocale: 'en',
+};
+export default config;


### PR DESCRIPTION
## 摘要
- 新增 `next-intl.config.ts`，設定 `ms`、`en`、`zh-CN` 三種語系

## 測試
- `pnpm lint`（缺少 eslint 套件而失敗）
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68bd7e2c42108329ab47ffde372f3148