### PR TITLE
新增多語系訊息檔案

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,13 @@
+{
+  "common": {
+    "nav": {
+      "home": "Home",
+      "products": "Products",
+      "contact": "Contact"
+    },
+    "home": {
+      "heroTitle": "Discover Unique Gifts",
+      "heroSubtitle": "Delight Your Loved Ones"
+    }
+  }
+}

--- a/messages/ms.json
+++ b/messages/ms.json
@@ -1,0 +1,13 @@
+{
+  "common": {
+    "nav": {
+      "home": "Laman Utama",
+      "products": "Produk",
+      "contact": "Hubungi"
+    },
+    "home": {
+      "heroTitle": "Temui Hadiah Unik",
+      "heroSubtitle": "Gembirakan Orang Tersayang"
+    }
+  }
+}

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1,0 +1,13 @@
+{
+  "common": {
+    "nav": {
+      "home": "首页",
+      "products": "产品",
+      "contact": "联系我们"
+    },
+    "home": {
+      "heroTitle": "发现独特礼品",
+      "heroSubtitle": "为挚爱送上惊喜"
+    }
+  }
+}


### PR DESCRIPTION
## 摘要
- 建立 `messages` 目錄並加入 `en`, `ms`, `zh-CN` 三種語系檔
- 提供導覽與首頁橫幅文案的多語系內容

## 測試
- `npm test`（缺少 script）
- `npm run lint`（需互動式設定）
- `npm run build`（網路錯誤無法取得字型）

------
https://chatgpt.com/codex/tasks/task_e_68bd8c0a73548329975ee4c7902f2d0a