### PR TITLE
加入 next-intl middleware 處理多語系路由

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,7 @@
+import createMiddleware from 'next-intl/middleware';
+import intlConfig from './next-intl.config';
+
+export default createMiddleware(intlConfig);
+export const config = {
+  matcher: ['/((?!_next|.*\\..*).*)'], // 覆蓋所有非靜態檔案路徑
+};


### PR DESCRIPTION
## 摘要
- 新增 `middleware.ts`，整合 next-intl 中介層
- 匹配所有非靜態路徑以支援多語系

## 測試
- `npm test`（無測試腳本）
- `npm run lint`（缺少 ESLint 設定，操作已取消）
- `npm run dev` 併 `curl -I` 測試 `/en`、`/ms`、`/zh-CN` 等路徑

------
https://chatgpt.com/codex/tasks/task_e_68bd90b0519c8329b6f3d7e1f5c87327