### PR TITLE
設定預設語系為馬來文

### DIFF
--- a/next-intl.config.ts
+++ b/next-intl.config.ts
@@ -1,6 +1,6 @@
 import {NextIntlConfig} from 'next-intl';
 const config: NextIntlConfig = {
   locales: ['ms', 'en', 'zh-CN'],
-  defaultLocale: 'en',
+  defaultLocale: 'ms',
 };
 export default config;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
   },
   i18n: {
     locales: ["ms", "en", "zh-CN"],
-    defaultLocale: "en",
+    defaultLocale: "ms",
   },
 }
 


### PR DESCRIPTION
## 摘要
- 將 `next-intl.config.ts` 與 `next.config.mjs` 的預設語系改為 `ms`
- 確認 locales 陣列包含 `ms`, `en`, `zh-CN`

## 測試
- `npm test`（缺少 script）
- `npm run lint`（互動式設定，無法自動完成）

------
https://chatgpt.com/codex/tasks/task_e_68bda7d2b99c8329b0bbb69d7f0d82f6