### PR TITLE
更新語言切換器顯示英文、馬來文與中文

### DIFF
--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -5,9 +5,9 @@ import { useLocale } from 'next-intl'
 import { Button } from '@/components/ui/button'
 
 const languages = [
-  { code: 'ms', label: 'ms' },
-  { code: 'en', label: 'en' },
-  { code: 'zh-CN', label: 'zh-CN' },
+  { code: 'en', label: 'English' },
+  { code: 'ms', label: 'Malay' },
+  { code: 'zh-CN', label: '中文' },
 ]
 
 export function LanguageSwitcher() {


### PR DESCRIPTION
## Summary
- 語言選單新增 English、Malay、中文 標籤，連結至相同路徑並切換 locale

## Testing
- `pnpm lint` *(失敗：缺少 ESLint 配置)*

------
https://chatgpt.com/codex/tasks/task_e_68bda90d27f08329886addb1c331405f