### PR TITLE
使用 requestLocale 取得語系

### DIFF
--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,19 +1,17 @@
-import {getRequestConfig} from 'next-intl/server';
+import {getRequestConfig, requestLocale} from 'next-intl/server';
 import type {AbstractIntlMessages} from 'next-intl';
 
 // 和 next.config.mjs 保持一致
 export const locales = ['ms', 'en', 'zh-CN'] as const;
 export const defaultLocale = 'ms';
 
-export default getRequestConfig(async ({locale}) => {
-  const resolved =
-    locales.includes((locale as any) ?? '')
-      ? (locale as (typeof locales)[number])
-      : defaultLocale;
-
+export default getRequestConfig(async () => {
+  const locale = await requestLocale();
+  const resolved = locales.includes(locale as any)
+    ? (locale as (typeof locales)[number])
+    : defaultLocale;
   return {
     locale: resolved,
-    messages: (await import(`../messages/${resolved}.json`))
-      .default as AbstractIntlMessages
+    messages: (await import(`../messages/${resolved}.json`)).default as AbstractIntlMessages
   };
 });


### PR DESCRIPTION
## Summary
- 更新 i18n/request.ts 以使用 requestLocale 解析語系

## Testing
- `npm run lint` *(interrupted: 需要互動式設定 ESLint)*
- `npm run build` *(failed: Failed to fetch font `DM Sans` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc0ffd8e483299b57d365d3e7f51e