### PR TITLE
調整 middleware，確保語系攔截涵蓋所有路徑

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,5 +3,5 @@ import intlConfig from './next-intl.config';
 
 export default createMiddleware(intlConfig);
 export const config = {
-  matcher: ['/((?!_next|.*\\..*).*)'], // 覆蓋所有非靜態檔案路徑
+  matcher: ['/', '/(ms|en|zh-CN)/:path*']
 };


### PR DESCRIPTION
## Summary
- 調整 `middleware.ts` 的 `matcher`，改為 `['/', '/(ms|en|zh-CN)/:path*']`

## Testing
- `npm run build`（失敗：無法從 Google Fonts 下載字體）

------
https://chatgpt.com/codex/tasks/task_e_68bdcc617eb883299971313fc3a6826b