### PR TITLE
建立網站 sitemap

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next'
+import { products } from '../data/products'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+
+  const routes: MetadataRoute.Sitemap = ['', 'contact', 'products'].map((path) => ({
+    url: `${baseUrl}/${path}`,
+    lastModified: new Date().toISOString(),
+  }))
+
+  products.forEach((p) => {
+    routes.push({
+      url: `${baseUrl}/products/${p.id}`,
+      lastModified: new Date().toISOString(),
+    })
+  })
+
+  return routes
+}


### PR DESCRIPTION
## Summary
- 建立 `app/sitemap.ts` 依據環境變數自動產生首頁、聯絡頁、產品頁與產品詳細頁的 sitemap

## Testing
- `pnpm lint` *(失敗：首次執行需配置 ESLint)*
- `pnpm build` *(失敗：無法從 Google Fonts 下載字體)*

------
https://chatgpt.com/codex/tasks/task_e_68c26e39a5fc8329a84885ca8c89d190